### PR TITLE
Fix library version in the properties file

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=GyverOLED
-version=0.5
+version=1.0
 author=AlexGyver <alex@alexgyver.ru>
 maintainer=AlexGyver <alex@alexgyver.ru>
 sentence=Fast and light library for SSD1306/SSH1106 OLED display


### PR DESCRIPTION
В данный момент версия библиотеки `1.0`, но в манифесте указано устаревшее значение. Данный PR это исправляет.

Лучше всего **после** принятия этого PR перевыпустить релиз, т.е.:

- Удалить существующий релиз `1.0`
- Удалить git-тег `1.0`
- Опубликовать релиз `1.0` (соответствующий тег будет создан автоматически)