### PR TITLE
Added switching to higher I2C clock speeds for faster buffer transfer

### DIFF
--- a/src/GyverOLED.h
+++ b/src/GyverOLED.h
@@ -189,6 +189,9 @@ public:
             }
         } else {
             Wire.begin();
+            #ifdef FAST_I2C
+            Wire.setClock(1000000);
+            #endif
         }
         
         beginCommand();


### PR DESCRIPTION
You just need to add `#define FAST_I2C` to switch to higher speed. Works with ESP32, wasn't able to test with arduino
(I am sorry, I'm just starting to use github)