### PR TITLE
SSH1106 no_buffer text support

### DIFF
--- a/src/GyverOLED.h
+++ b/src/GyverOLED.h
@@ -227,7 +227,7 @@ public:
             writeData(0, y, x, 2);
             if (!_BUFF) endTransm();			
         } else {
-            // для SSH1108
+            // для SSH1106
         }
     }
     
@@ -337,6 +337,7 @@ public:
             setWindowShift(x, y, _maxX, _scaleY);
         } else {
             // SSH1106 without buffer
+            _shift = y & 0b111; // setup y-shift
             // m_col = x + 2;
             // m_row = y;
             sendCommand(0xb0 + (y >> 3)); //set page address
@@ -701,7 +702,7 @@ public:
                     }
                 }
                 // Return cursor home
-                setCursorXY(0, 0);
+                setCursorXY(_x, _y);
             }
         }		
     }

--- a/src/GyverOLED.h
+++ b/src/GyverOLED.h
@@ -735,14 +735,14 @@ public:
                     sendCommand(2 & 0xf);       // Set lower column address
                     sendCommand(0x10);          // Set higher column address
                     // Divide for blocks
+                    beginData();
                     for (uint8_t a = 0; a < 8; a++) {
-                        beginData();
                         // For each block
                         for (uint8_t b = 0; b < (OLED_WIDTH >> 3); b++) {
                             sendByte(data);
                         }
-                        endTransm();
                     }
+                    endTransm();
                 }
                 // Return cursor home
                 setCursorXY(_x, _y);

--- a/src/GyverOLED.h
+++ b/src/GyverOLED.h
@@ -375,18 +375,8 @@ public:
     void setCursorXY(int x, int y) { 			
         _x = x;
         _y = y;	
-        if (_TYPE < 2 || _BUFF) {
-            // SSD1306 or SSH1106 witthout buffer
-            setWindowShift(x, y, _maxX, _scaleY);
-        } else {
-            // SSH1106 without buffer
-            _shift = y & 0b111; // setup y-shift
-            // m_col = x + 2;
-            // m_row = y;
-            sendCommand(0xb0 + (y >> 3)); //set page address
-            sendCommand((x + 2) & 0xf); //set lower column address
-            sendCommand(0x10 | ((x + 2) >> 4)); //set higher column address
-        }
+        setWindowShift(x, y, _maxX, _scaleY);
+        setWindowAddress(x, y);
     }
     
     // масштаб шрифта (1-4)
@@ -970,7 +960,7 @@ public:
         sendByteRaw(cmd2);
         endTransm();
     }	
-    
+
     // выбрать "окно" дисплея
     void setWindow(int x0, int y0, int x1, int y1) {		
         beginCommand();
@@ -981,6 +971,15 @@ public:
         sendByteRaw(constrain(y0, 0, _maxRow));
         sendByteRaw(constrain(y1, 0, _maxRow));
         endTransm();
+    }
+
+    void setWindowAddress(int x, int y) {
+        // for SSH1106 without buffer
+        if (_TYPE && !_BUFF) {
+            sendCommand(0xb0 + (y >> 3)); //set page address
+            sendCommand((x + 2) & 0xf); //set lower column address
+            sendCommand(0x10 | ((x + 2) >> 4)); //set higher column address
+        }
     }
     
     void beginData() {


### PR DESCRIPTION
# Добавил поддержку текста OLED SSH1106 NO_BUFFER

## Определения
page - горизонтальные фрагменты дисплея высотой 8 пикселей (1 байт). Наглядно на 16 странице datasheet
NO BUFFER - буфер на стороне дисплея

## Что добавлено
- clear() - очистка экрана
- setCursorXY() - добавлена функция setWindowAddress() относящаяся к этому дисплею
- write() - работа с выводом текста print()

Проверена работа на дисплее SSH1106 по SPI.
Не проверена работа по I2C и совместимость корректировок с другими дисплеями.

## Дополнительно

Для отрисовки текста устанавливается столбец 0-127 по X и page 0-8 по Y. setCursor(), setCursorXY().
Команда отправляется на отрисовку сразу нескольких пикселей одной страницы page.
Символы в увеличенном масштабе (scale 2, 3, 4) разбиваются на несколько страниц page.
При смещении _shift текст разбивается на 2 страницы page.

Команды для дисплея SSH1106 128x64 выполняются аналогично командам по дисплею SH1106 132x64. При этом координаты по X сдвигаются на +2. Может лучше добавить отдельную константу, определяющую этот сдвиг по X? тогда можно будет использовать и SH1106 и SSH1106 с отличием только в этой константе.
[Есть даташит только на SH1106](https://www.velleman.eu/downloads/29/infosheets/sh1106_datasheet.pdf) (132x64)

## Референсы библиотек по работе с SSH1106
- [Adafruit](https://github.com/adafruit/Adafruit_SSD1306)
- [SSD1306Ascii](https://github.com/greiman/SSD1306Ascii)

## Todo
- Чтение байтов непосредственно с дисплея. Так как запись производится по одному вертикальному байту (по 8 точек по-вертикали), то без чтения с дисплея байты перезаписываются.
- Графика, точки, линии, прямоугольники, окружности (есть наработки в ветке [1106buffer](https://github.com/AlexanderAni/GyverOLED/tree/1106buffer) моего репозитория)
- Bitmap. Вероятно, надо разбивать bitmap на вертикальные страницы page