### PR TITLE
Исправление #49 и неполного частичного обновления экрана

### DIFF
--- a/src/GyverOLED.h
+++ b/src/GyverOLED.h
@@ -544,7 +544,6 @@ class GyverOLED {
             }
             byte thisFill = (fill == OLED_FILL ? 0 : 1);
             // рисуем в олед и в большой буфер
-            x1++;
             y1++;
             byte shift = y0 & 0b111;
             byte shift2 = 8 - (y1 & 0b111);

--- a/src/GyverOLED.h
+++ b/src/GyverOLED.h
@@ -804,8 +804,8 @@ class GyverOLED {
             y1 >>= 3;
             setWindow(x0, y0, x1, y1);
             beginData();
-            for (int x = x0; x < x1; x++)
-                for (int y = y0; y < y1 + 1; y++)
+            for (int x = x0; x <= x1; x++)
+                for (int y = y0; y <= y1; y++)
                     if (x >= 0 && x <= _maxX && y >= 0 && y <= _maxRow)
                         sendByte(_oled_buffer[y + x * (_TYPE ? 8 : 4)]);
             endTransm();


### PR DESCRIPTION
### Баг 1 #49  Метод `rect` с праметром `OLED_FILL` избыточно рисует прямоугольник по оси x на один лишний пиксель.

[Данную](https://github.com/GyverLibs/GyverOLED/blob/1bed45d581a49aa257a29981d55224173e2e5a7a/src/GyverOLED.h#L547) строчку я удалил т.к. [ниже](https://github.com/GyverLibs/GyverOLED/blob/1bed45d581a49aa257a29981d55224173e2e5a7a/src/GyverOLED.h#L561) в цикле итерирование идет включительно (<=) и поэтому инкрементирование избыточно. 

### Баг 2 Обновление части экрана не учитывает правую границу

[Здесь](https://github.com/GyverLibs/GyverOLED/blob/1bed45d581a49aa257a29981d55224173e2e5a7a/src/GyverOLED.h#L809) в цикле граница учтена, а [тут](https://github.com/GyverLibs/GyverOLED/blob/1bed45d581a49aa257a29981d55224173e2e5a7a/src/GyverOLED.h#L808) была забыта.

### Демонстрация проблемы (доступна также в [симуляторе](https://wokwi.com/projects/406033586231550977))

Код примера
```
#define USE_FIX_VERSION 1

#if USE_FIX_VERSION
#include "GyverOLEDFix.h"
#else
#include "GyverOLED.h"
#endif

GyverOLED<SSD1306_128x64, OLED_BUFFER> oled;


void setup() {
  oled.init();
  oled.clear();

  // ************************************** ПРОБЛЕМА #49 **************************************
  drawLine(0, 0, 1, 0);
  oled.rect(0, 2, 6, 8, OLED_FILL);
  drawLine(0, 10, 1, 0);
  oled.rect(0, 12, 6, 18, OLED_STROKE);
  drawLine(0, 20, 1, 0);
  oled.roundRect(0, 22, 6, 28, OLED_FILL);
  drawLine(0, 30, 1, 0);
  oled.roundRect(0, 32, 6, 38, OLED_STROKE);
  drawLine(0, 40, 1, 0);
  drawLine(10, 0, 0, 1);
  oled.update();
  // ************************************** ПРОБЛЕМА неполного частичного обновления **********
  oled.roundRect(0, 42, 6, 48, OLED_STROKE);
  oled.update(0, 42, 6, 48);
}

void loop() {
}

void drawLine(int x, int y, char vecX, char vecY){
  for(int i = 0; i < 128; i+=2) {
    oled.dot(x + i * vecX, y + i * vecY, 1);
  }
}
```
Пример того как это было

![image](https://github.com/user-attachments/assets/c79c6eff-4c43-4ccf-a3a8-de2f224b5cb3)

Результат исправлений

![image](https://github.com/user-attachments/assets/b266dda6-43d0-4868-b7e0-76dc22701451)


